### PR TITLE
Release/v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Security
 -->
 
-## [UNRELEASED]
+## v2.0.0 - 2020-07-15
 
 ### Changed
 - Added support for node 10, 12 and 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Security
 -->
 
+## [UNRELEASED]
+
+### Changed
+- Added support for node 10, 12 and 14
+- Updated dev dependencies
+
+### Deprecated
+- **BREAKING** Drop support for node 4 and 7
+
 
 
 
 ## v1.0.1 - 2017-11-12
+
 ### Fixed
 - Fix package.json path reference
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "changelog-version",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "changelog-version",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Build tool to update CHANGELOG.md file with the version",
   "main": "index.js",
   "bin": "./bin/changelog-version.js",


### PR DESCRIPTION
## v2.0.0 - 2020-07-15

### Changed
- Added support for node 10, 12 and 14
- Updated dev dependencies

### Deprecated
- **BREAKING** Drop support for node 4 and 7